### PR TITLE
002 allow completed tasks to be unchecked

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -3,6 +3,8 @@
 Auto-generated from all feature plans. Last updated: 2026-03-04
 
 ## Active Technologies
+- TypeScript 5.4 (backend: Node.js/Fastify; frontend: React/Next.js 14) + Fastify (backend API), React + Tailwind CSS (frontend), Prisma ORM (002-uncheck-completed)
+- PostgreSQL 16 (primary data), Redis 7 (session cache, BullMQ job queue) (002-uncheck-completed)
 
 - TypeScript 5.x (frontend + backend) + Next.js 14 (frontend), Fastify 4 (backend API), Prisma (ORM), (001-mvp-core)
 
@@ -22,6 +24,7 @@ npm test && npm run lint
 TypeScript 5.x (frontend + backend): Follow standard conventions
 
 ## Recent Changes
+- 002-uncheck-completed: Added TypeScript 5.4 (backend: Node.js/Fastify; frontend: React/Next.js 14) + Fastify (backend API), React + Tailwind CSS (frontend), Prisma ORM
 
 - 001-mvp-core: Added TypeScript 5.x (frontend + backend) + Next.js 14 (frontend), Fastify 4 (backend API), Prisma (ORM),
 

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,1 @@
+{"servers":{"MCP_DOCKER":{"command":"docker","args":["mcp","gateway","run"],"type":"stdio"}}}

--- a/backend/prisma/migrations/20260308060721_add_sync_override/migration.sql
+++ b/backend/prisma/migrations/20260308060721_add_sync_override/migration.sql
@@ -1,0 +1,25 @@
+-- CreateEnum
+CREATE TYPE "OverrideType" AS ENUM ('REOPENED');
+
+-- CreateTable
+CREATE TABLE "SyncOverride" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "syncCacheItemId" TEXT NOT NULL,
+    "overrideType" "OverrideType" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SyncOverride_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SyncOverride_userId_idx" ON "SyncOverride"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SyncOverride_syncCacheItemId_overrideType_key" ON "SyncOverride"("syncCacheItemId", "overrideType");
+
+-- AddForeignKey
+ALTER TABLE "SyncOverride" ADD CONSTRAINT "SyncOverride_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SyncOverride" ADD CONSTRAINT "SyncOverride_syncCacheItemId_fkey" FOREIGN KEY ("syncCacheItemId") REFERENCES "SyncCacheItem"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -37,6 +37,10 @@ enum ItemType {
   message
 }
 
+enum OverrideType {
+  REOPENED
+}
+
 model User {
   id                  String    @id @default(uuid())
   email               String    @unique
@@ -54,6 +58,7 @@ model User {
 
   integrations  Integration[]
   nativeTasks   NativeTask[]
+  syncOverrides SyncOverride[]
 
   @@index([email])
 }
@@ -97,6 +102,7 @@ model SyncCacheItem {
   rawPayload           Json
 
   integration Integration @relation(fields: [integrationId], references: [id], onDelete: Cascade)
+  syncOverrides SyncOverride[]
 
   @@unique([integrationId, externalId])
   @@index([userId])
@@ -118,4 +124,18 @@ model NativeTask {
 
   @@index([userId])
   @@index([userId, completed])
+}
+
+model SyncOverride {
+  id              String       @id @default(uuid())
+  userId          String
+  syncCacheItemId String
+  overrideType    OverrideType
+  createdAt       DateTime     @default(now())
+
+  user          User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  syncCacheItem SyncCacheItem @relation(fields: [syncCacheItemId], references: [id], onDelete: Cascade)
+
+  @@unique([syncCacheItemId, overrideType])
+  @@index([userId])
 }

--- a/backend/src/api/feed.routes.ts
+++ b/backend/src/api/feed.routes.ts
@@ -9,6 +9,8 @@ import {
   buildFeed,
   completeSyncItem,
   completeNativeTask,
+  uncompleteNativeTask,
+  uncompleteSyncItem,
 } from '../feed/feed.service.js';
 import { logger } from '../lib/logger.js';
 
@@ -79,6 +81,54 @@ export async function registerFeedRoutes(app: FastifyInstance): Promise<void> {
         const msg = (err as Error).message;
         if (msg.includes('not found')) {
           return reply.status(404).send({ error: 'Not Found', message: msg });
+        }
+        throw err;
+      }
+    }
+  );
+
+  // PATCH /api/feed/items/:itemId/uncomplete
+  app.patch(
+    '/api/feed/items/:itemId/uncomplete',
+    async (
+      request: FastifyRequest<{ Params: { itemId: string } }>,
+      reply
+    ) => {
+      const userId = requireAuth(request, reply);
+      if (!userId) return;
+
+      const { itemId } = request.params;
+
+      const [type, rawId] = itemId.split(':');
+
+      if (!type || !rawId) {
+        return reply.status(400).send({
+          error: 'Bad Request',
+          message: 'Invalid itemId format. Expected "sync:<uuid>" or "native:<uuid>"',
+        });
+      }
+
+      try {
+        let result;
+        if (type === 'sync') {
+          result = await uncompleteSyncItem(rawId, userId);
+        } else if (type === 'native') {
+          result = await uncompleteNativeTask(rawId, userId);
+        } else {
+          return reply.status(400).send({
+            error: 'Bad Request',
+            message: 'Invalid item type. Use "sync" or "native"',
+          });
+        }
+
+        return reply.send(result);
+      } catch (err) {
+        const msg = (err as Error).message;
+        if (msg.includes('not found')) {
+          return reply.status(404).send({ error: 'Not Found', message: msg });
+        }
+        if (msg.includes('not completed')) {
+          return reply.status(400).send({ error: 'Bad Request', code: 'ITEM_NOT_COMPLETED', message: msg });
         }
         throw err;
       }

--- a/backend/src/api/tasks.routes.ts
+++ b/backend/src/api/tasks.routes.ts
@@ -9,6 +9,7 @@ import {
   createTask,
   updateTask,
   deleteTask,
+  uncompleteTask,
 } from '../tasks/task.service.js';
 
 function requireAuth(request: FastifyRequest, reply: FastifyReply): string | null {
@@ -104,6 +105,31 @@ export async function registerTaskRoutes(app: FastifyInstance): Promise<void> {
         const msg = (err as Error).message;
         if (msg.includes('not found')) {
           return reply.status(404).send({ error: 'Not Found', message: msg });
+        }
+        throw err;
+      }
+    }
+  );
+
+  // PATCH /api/tasks/:id/uncomplete
+  app.patch(
+    '/api/tasks/:id/uncomplete',
+    async (request: FastifyRequest<{ Params: { id: string } }>, reply) => {
+      const userId = requireAuth(request, reply);
+      if (!userId) return;
+
+      const { id } = request.params;
+
+      try {
+        const task = await uncompleteTask(userId, id);
+        return reply.send(task);
+      } catch (err) {
+        const msg = (err as Error).message;
+        if (msg.includes('not found')) {
+          return reply.status(404).send({ error: 'Not Found', message: msg });
+        }
+        if (msg.includes('not completed')) {
+          return reply.status(400).send({ error: 'Bad Request', code: 'ITEM_NOT_COMPLETED', message: msg });
         }
         throw err;
       }

--- a/backend/src/feed/feed.service.ts
+++ b/backend/src/feed/feed.service.ts
@@ -177,6 +177,7 @@ function buildSyncStatus(
 
 /**
  * Mark a sync cache item as complete in ordrctrl.
+ * Deletes any existing REOPENED SyncOverride for this item.
  * Returns the updated FeedItem fields.
  */
 export async function completeSyncItem(
@@ -194,6 +195,11 @@ export async function completeSyncItem(
   if (updated.count === 0) {
     throw new Error('Item not found or already completed');
   }
+
+  // Delete any REOPENED override — user is re-completing the item
+  await prisma.syncOverride.deleteMany({
+    where: { syncCacheItemId: itemId, overrideType: 'REOPENED' },
+  });
 
   const item = await prisma.syncCacheItem.findUnique({ where: { id: itemId } });
 
@@ -226,5 +232,79 @@ export async function completeNativeTask(
     id: `native:${taskId}`,
     completed: true,
     completedAt: task!.completedAt!.toISOString(),
+  };
+}
+
+/**
+ * Reopen a completed native task (uncheck).
+ */
+export async function uncompleteNativeTask(
+  taskId: string,
+  userId: string
+): Promise<{ id: string; completed: boolean; completedAt: null; isLocalOverride: false }> {
+  const item = await prisma.nativeTask.findFirst({
+    where: { id: taskId, userId },
+  });
+  if (!item) {
+    throw new Error('Task not found');
+  }
+  if (!item.completed) {
+    throw new Error('Task is not completed');
+  }
+
+  await prisma.nativeTask.update({
+    where: { id: taskId },
+    data: { completed: false, completedAt: null },
+  });
+
+  return {
+    id: `native:${taskId}`,
+    completed: false,
+    completedAt: null,
+    isLocalOverride: false,
+  };
+}
+
+/**
+ * Reopen a completed sync-sourced task (uncheck).
+ * Creates a SyncOverride(REOPENED) to preserve the user's intent across future sync cycles.
+ */
+export async function uncompleteSyncItem(
+  itemId: string,
+  userId: string
+): Promise<{ id: string; completed: boolean; completedAt: null; isLocalOverride: true }> {
+  const item = await prisma.syncCacheItem.findFirst({
+    where: { id: itemId, userId },
+    include: { integration: { select: { serviceId: true } } },
+  });
+  if (!item) {
+    throw new Error('Item not found');
+  }
+  if (!item.completedInOrdrctrl) {
+    throw new Error('Item is not completed');
+  }
+
+  await prisma.syncCacheItem.update({
+    where: { id: itemId },
+    data: { completedInOrdrctrl: false, completedAt: null },
+  });
+
+  // Upsert SyncOverride so re-calling this is idempotent
+  await prisma.syncOverride.upsert({
+    where: {
+      syncCacheItemId_overrideType: {
+        syncCacheItemId: itemId,
+        overrideType: 'REOPENED',
+      },
+    },
+    create: { userId, syncCacheItemId: itemId, overrideType: 'REOPENED' },
+    update: { createdAt: new Date() },
+  });
+
+  return {
+    id: `sync:${itemId}`,
+    completed: false,
+    completedAt: null,
+    isLocalOverride: true,
   };
 }

--- a/backend/src/sync/cache.service.ts
+++ b/backend/src/sync/cache.service.ts
@@ -12,6 +12,12 @@ const CACHE_TTL_HOURS = 24;
  * Upsert a batch of NormalizedItems into SyncCacheItem for a given integration.
  * Sets expiresAt = now + 24h.
  * Uses upsert on [integrationId, externalId] to avoid duplicates.
+ *
+ * NOTE: The update block intentionally omits `completedInOrdrctrl` and `completedAt`.
+ * Local completion state is owned by ordrctrl and must never be overwritten by sync.
+ * A SyncOverride(REOPENED) record is the explicit signal that the user has locally
+ * reopened an item — sync must always respect it. If two-way sync (issue #10) ever
+ * needs to push source completion state, it must first check for a SyncOverride.
  */
 export async function persistCacheItems(
   integrationId: string,

--- a/backend/src/tasks/task.service.ts
+++ b/backend/src/tasks/task.service.ts
@@ -109,3 +109,24 @@ export async function completeTask(
   });
   return toFeedItem(task);
 }
+
+export async function uncompleteTask(
+  userId: string,
+  taskId: string
+): Promise<NativeTaskResult> {
+  const existing = await prisma.nativeTask.findFirst({
+    where: { id: taskId, userId },
+  });
+  if (!existing) {
+    throw new Error('Task not found');
+  }
+  if (!existing.completed) {
+    throw new Error('Task is not completed');
+  }
+
+  const task = await prisma.nativeTask.update({
+    where: { id: taskId },
+    data: { completed: false, completedAt: null },
+  });
+  return toFeedItem(task);
+}

--- a/backend/tests/contract/feed.test.ts
+++ b/backend/tests/contract/feed.test.ts
@@ -91,3 +91,35 @@ describe('DELETE /api/tasks/:id', () => {
     expect(res.status).toBe(401);
   });
 });
+
+describe('PATCH /api/feed/items/:itemId/uncomplete', () => {
+  it('returns 401 when unauthenticated', async () => {
+    if (!request) return;
+    const res = await request
+      .patch('/api/feed/items/native:00000000-0000-0000-0000-000000000000/uncomplete');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for malformed itemId (no colon separator)', async () => {
+    if (!request) return;
+    const res = await request
+      .patch('/api/feed/items/invalid-format/uncomplete');
+    expect([400, 401]).toContain(res.status);
+  });
+
+  it('returns 400 for unknown item type prefix', async () => {
+    if (!request) return;
+    const res = await request
+      .patch('/api/feed/items/unknown:00000000-0000-0000-0000-000000000000/uncomplete');
+    expect([400, 401]).toContain(res.status);
+  });
+});
+
+describe('PATCH /api/tasks/:id/uncomplete', () => {
+  it('returns 401 when unauthenticated', async () => {
+    if (!request) return;
+    const res = await request
+      .patch('/api/tasks/00000000-0000-0000-0000-000000000000/uncomplete');
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/tests/unit/feed.service.test.ts
+++ b/backend/tests/unit/feed.service.test.ts
@@ -1,5 +1,5 @@
 // T068 — Unit tests for FeedService
-// Ordering rules, duplicate detection, completed separation
+// Ordering rules, duplicate detection, completed separation, uncomplete logic
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -165,5 +165,116 @@ describe('FeedService — completed separation', () => {
 
     expect(completed[0].id).toBe('newer');
     expect(completed[1].id).toBe('older');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T018 — Unit tests for uncomplete logic
+// Using vi.mock to isolate Prisma interactions
+// ---------------------------------------------------------------------------
+
+vi.mock('../../src/lib/db.js', () => ({
+  prisma: {
+    nativeTask: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+    syncCacheItem: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+    syncOverride: {
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from '../../src/lib/db.js';
+import { uncompleteNativeTask, uncompleteSyncItem } from '../../src/feed/feed.service.js';
+
+const mockPrisma = prisma as unknown as {
+  nativeTask: { findFirst: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> };
+  syncCacheItem: { findFirst: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> };
+  syncOverride: { upsert: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('uncompleteNativeTask()', () => {
+  it('returns uncompleted feed item on success', async () => {
+    mockPrisma.nativeTask.findFirst.mockResolvedValue({ id: 'task-1', userId: 'user-1', completed: true, completedAt: new Date() });
+    mockPrisma.nativeTask.update.mockResolvedValue({ id: 'task-1', title: 'My task', dueAt: null, completed: false, completedAt: null });
+
+    const result = await uncompleteNativeTask('task-1', 'user-1');
+
+    expect(result.id).toBe('native:task-1');
+    expect(result.completed).toBe(false);
+    expect(result.completedAt).toBeNull();
+    expect(result.isLocalOverride).toBe(false);
+  });
+
+  it('throws when task not found', async () => {
+    mockPrisma.nativeTask.findFirst.mockResolvedValue(null);
+
+    await expect(uncompleteNativeTask('missing', 'user-1')).rejects.toThrow('Task not found');
+  });
+
+  it('throws when task is already open', async () => {
+    mockPrisma.nativeTask.findFirst.mockResolvedValue({ id: 'task-1', userId: 'user-1', completed: false, completedAt: null });
+
+    await expect(uncompleteNativeTask('task-1', 'user-1')).rejects.toThrow('Task is not completed');
+  });
+});
+
+describe('uncompleteSyncItem()', () => {
+  it('returns uncompleted feed item with isLocalOverride=true on success', async () => {
+    mockPrisma.syncCacheItem.findFirst.mockResolvedValue({
+      id: 'item-1', userId: 'user-1', completedInOrdrctrl: true,
+      integration: { serviceId: 'gmail' },
+    });
+    mockPrisma.syncCacheItem.update.mockResolvedValue({});
+    mockPrisma.syncOverride.upsert.mockResolvedValue({});
+
+    const result = await uncompleteSyncItem('item-1', 'user-1');
+
+    expect(result.id).toBe('sync:item-1');
+    expect(result.completed).toBe(false);
+    expect(result.completedAt).toBeNull();
+    expect(result.isLocalOverride).toBe(true);
+  });
+
+  it('creates a SyncOverride(REOPENED) record', async () => {
+    mockPrisma.syncCacheItem.findFirst.mockResolvedValue({
+      id: 'item-1', userId: 'user-1', completedInOrdrctrl: true,
+      integration: { serviceId: 'gmail' },
+    });
+    mockPrisma.syncCacheItem.update.mockResolvedValue({});
+    mockPrisma.syncOverride.upsert.mockResolvedValue({});
+
+    await uncompleteSyncItem('item-1', 'user-1');
+
+    expect(mockPrisma.syncOverride.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { syncCacheItemId_overrideType: { syncCacheItemId: 'item-1', overrideType: 'REOPENED' } },
+        create: expect.objectContaining({ overrideType: 'REOPENED' }),
+      })
+    );
+  });
+
+  it('throws when item not found', async () => {
+    mockPrisma.syncCacheItem.findFirst.mockResolvedValue(null);
+
+    await expect(uncompleteSyncItem('missing', 'user-1')).rejects.toThrow('Item not found');
+  });
+
+  it('throws when item is already open', async () => {
+    mockPrisma.syncCacheItem.findFirst.mockResolvedValue({
+      id: 'item-1', userId: 'user-1', completedInOrdrctrl: false,
+      integration: { serviceId: 'gmail' },
+    });
+
+    await expect(uncompleteSyncItem('item-1', 'user-1')).rejects.toThrow('Item is not completed');
   });
 });

--- a/frontend/src/app/feed/page.tsx
+++ b/frontend/src/app/feed/page.tsx
@@ -17,7 +17,7 @@ import { EditTaskModal } from '@/components/tasks/EditTaskModal';
 import type { FeedItem } from '@/services/feed.service';
 
 export default function FeedPage() {
-  const { items, completed, syncStatus, loading, refreshing, error, refresh, completeItem } =
+  const { items, completed, syncStatus, loading, refreshing, error, refresh, completeItem, uncompleteItem } =
     useFeed();
   const { create, update, remove } = useNativeTasks(refresh);
 
@@ -146,7 +146,7 @@ export default function FeedPage() {
         )}
 
         {/* Completed section */}
-        <CompletedSection items={completed} />
+        <CompletedSection items={completed} onUncomplete={uncompleteItem} />
       </main>
 
       {/* Floating Action Button — Add task */}

--- a/frontend/src/components/feed/CompletedSection.tsx
+++ b/frontend/src/components/feed/CompletedSection.tsx
@@ -9,9 +9,10 @@ import type { FeedItem } from '@/services/feed.service';
 
 interface CompletedSectionProps {
   items: FeedItem[];
+  onUncomplete: (itemId: string) => void;
 }
 
-export function CompletedSection({ items }: CompletedSectionProps) {
+export function CompletedSection({ items, onUncomplete }: CompletedSectionProps) {
   const [open, setOpen] = useState(false);
 
   if (items.length === 0) return null;
@@ -43,7 +44,8 @@ export function CompletedSection({ items }: CompletedSectionProps) {
             <FeedItemRow
               key={item.id}
               item={item}
-              onComplete={() => {}} // completed items can't be re-completed
+              onComplete={() => {}} // completed items can't be re-completed via this handler
+              onUncomplete={onUncomplete}
             />
           ))}
         </div>

--- a/frontend/src/components/feed/FeedItem.tsx
+++ b/frontend/src/components/feed/FeedItem.tsx
@@ -2,6 +2,7 @@
 
 // T051 — FeedItem component
 
+import { useState } from 'react';
 import type { FeedItem as FeedItemType } from '@/services/feed.service';
 
 const SOURCE_COLORS: Record<string, string> = {
@@ -37,10 +38,12 @@ function formatTime(iso: string | null): string {
 interface FeedItemProps {
   item: FeedItemType;
   onComplete: (id: string) => void;
+  onUncomplete?: (id: string) => void;
   onClick?: (item: FeedItemType) => void;
 }
 
-export function FeedItemRow({ item, onComplete, onClick }: FeedItemProps) {
+export function FeedItemRow({ item, onComplete, onUncomplete, onClick }: FeedItemProps) {
+  const [noticeDismissed, setNoticeDismissed] = useState(false);
   const sourceColor = SOURCE_COLORS[item.source] ?? '#a1a1aa';
   const dateStr = item.dueAt
     ? formatDate(item.dueAt)
@@ -56,11 +59,17 @@ export function FeedItemRow({ item, onComplete, onClick }: FeedItemProps) {
       {/* Checkbox */}
       <button
         type="button"
-        aria-label={item.completed ? 'Completed' : 'Mark complete'}
-        onClick={() => !item.completed && onComplete(item.id)}
+        aria-label={item.completed ? 'Reopen task' : 'Mark complete'}
+        onClick={() => {
+          if (item.completed) {
+            onUncomplete?.(item.id);
+          } else {
+            onComplete(item.id);
+          }
+        }}
         className={`w-[1.125rem] h-[1.125rem] border flex-shrink-0 mt-0.5 flex items-center justify-center p-0 ${
           item.completed
-            ? 'border-zinc-400 bg-zinc-400 cursor-default'
+            ? 'border-zinc-400 bg-zinc-400 cursor-pointer hover:bg-zinc-300 hover:border-zinc-300'
             : 'border-zinc-300 bg-white cursor-pointer'
         }`}
       >
@@ -121,6 +130,21 @@ export function FeedItemRow({ item, onComplete, onClick }: FeedItemProps) {
           )}
         </div>
       </div>
+
+      {/* Inline local-override notice for reopened sync items */}
+      {item.isJustReopened && !noticeDismissed && item.source !== 'ordrctrl' && (
+        <div className="flex items-center gap-1.5 mt-1 ml-[1.875rem] text-[0.7rem] text-zinc-400">
+          <span>This change is local to ordrctrl and won't update {item.source}.</span>
+          <button
+            type="button"
+            aria-label="Dismiss notice"
+            onClick={() => setNoticeDismissed(true)}
+            className="bg-transparent border-0 p-0 cursor-pointer text-zinc-400 leading-none"
+          >
+            ×
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/hooks/useFeed.ts
+++ b/frontend/src/hooks/useFeed.ts
@@ -15,6 +15,7 @@ interface UseFeedReturn {
   refreshing: boolean;
   refresh: () => Promise<void>;
   completeItem: (itemId: string) => Promise<void>;
+  uncompleteItem: (itemId: string) => Promise<void>;
 }
 
 const POLL_INTERVAL_MS = 60 * 1000; // 60 seconds
@@ -82,6 +83,41 @@ export function useFeed(): UseFeedReturn {
     []
   );
 
+  const uncompleteItem = useCallback(
+    async (itemId: string) => {
+      // Snapshot for rollback
+      let snapshot: typeof data | null = null;
+      setData((prev) => {
+        snapshot = prev;
+        const item = prev.completed.find((i) => i.id === itemId);
+        if (!item) return prev;
+        return {
+          ...prev,
+          completed: prev.completed.filter((i) => i.id !== itemId),
+          items: [{ ...item, completed: false, completedAt: null }, ...prev.items],
+        };
+      });
+
+      try {
+        const result = await feedService.uncompleteItem(itemId);
+        if (result.isLocalOverride) {
+          // Mark the item as just reopened so the inline notice renders
+          setData((prev) => ({
+            ...prev,
+            items: prev.items.map((i) =>
+              i.id === itemId ? { ...i, isJustReopened: true } : i
+            ),
+          }));
+        }
+      } catch (err) {
+        // Roll back optimistic update
+        if (snapshot) setData(snapshot);
+        setError((err as Error).message);
+      }
+    },
+    []
+  );
+
   return {
     items: data.items,
     completed: data.completed,
@@ -91,5 +127,6 @@ export function useFeed(): UseFeedReturn {
     error,
     refresh,
     completeItem,
+    uncompleteItem,
   };
 }

--- a/frontend/src/services/feed.service.ts
+++ b/frontend/src/services/feed.service.ts
@@ -13,6 +13,7 @@ export interface FeedItem {
   completed: boolean;
   completedAt: string | null;
   isDuplicateSuspect: boolean;
+  isJustReopened?: boolean;
 }
 
 export interface SyncStatusEntry {
@@ -43,6 +44,20 @@ export async function completeItem(itemId: string): Promise<void> {
     const data = await res.json().catch(() => ({}));
     throw new Error(data.message || 'Failed to complete item');
   }
+}
+
+export async function uncompleteItem(
+  itemId: string
+): Promise<{ id: string; completed: false; completedAt: null; isLocalOverride: boolean }> {
+  const res = await fetch(`${API_URL}/api/feed/items/${itemId}/uncomplete`, {
+    method: 'PATCH',
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.message || 'Failed to reopen item');
+  }
+  return res.json();
 }
 
 export async function triggerSync(): Promise<void> {

--- a/specs/002-uncheck-completed/checklists/requirements.md
+++ b/specs/002-uncheck-completed/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Uncheck Completed Tasks
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Sync conflict resolution: local override wins — user action always takes precedence
+  over source system state (confirmed by user).
+- `Sync Override` entity intentionally designed to be extensible toward two-way sync
+  in a future feature.
+- Selective task import (choose which tasks to pull from integrations) is explicitly
+  out of scope and noted as a future feature (issue #6).

--- a/specs/002-uncheck-completed/contracts/api.md
+++ b/specs/002-uncheck-completed/contracts/api.md
@@ -1,0 +1,94 @@
+# API Contracts: Uncheck Completed Tasks
+
+## New Endpoints
+
+---
+
+### PATCH /api/feed/items/:itemId/uncomplete
+
+Reopens a completed feed item (native task or sync cache item) for the authenticated user.
+For sync-sourced items, creates a `SyncOverride(REOPENED)` record to preserve user intent
+across future sync cycles.
+
+**Authentication**: Required (session cookie)
+
+**Path Parameters**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `itemId` | string (UUID) | ID of the feed item to reopen |
+
+**Request Body**: None
+
+**Success Response** — `200 OK`
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "completed": false,
+  "completedAt": null,
+  "source": "ordrctrl" | "gmail" | "apple_reminders" | "microsoft_tasks" | "apple_calendar",
+  "isLocalOverride": false | true
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Item ID |
+| `completed` | `false` | Always false on success |
+| `completedAt` | `null` | Always null on success |
+| `source` | string | Origin of the item |
+| `isLocalOverride` | boolean | `true` if a SyncOverride was created (sync-sourced items only) |
+
+**Error Responses**
+
+| Status | Code | Description |
+|--------|------|-------------|
+| `400 Bad Request` | `ITEM_NOT_COMPLETED` | Item is already open (not completed) |
+| `403 Forbidden` | `FORBIDDEN` | Item does not belong to authenticated user |
+| `404 Not Found` | `ITEM_NOT_FOUND` | No item found with given ID |
+| `503 Service Unavailable` | `DB_ERROR` | Database write failed |
+
+---
+
+### PATCH /api/tasks/:id/uncomplete
+
+Reopens a completed native task for the authenticated user.
+(Alternative entry point for native tasks; preferred path is the feed endpoint above.)
+
+**Authentication**: Required (session cookie)
+
+**Path Parameters**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) | ID of the native task |
+
+**Request Body**: None
+
+**Success Response** — `200 OK`
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "title": "Buy groceries",
+  "completed": false,
+  "completedAt": null,
+  "dueAt": null,
+  "source": "ordrctrl"
+}
+```
+
+**Error Responses**: Same as feed endpoint above.
+
+---
+
+## Modified Behavior: Re-checking a Reopened Sync Item
+
+When `PATCH /api/feed/items/:itemId/complete` is called on an item that has a `SyncOverride(REOPENED)`:
+
+1. Sets `completedInOrdrctrl = true`, `completedAt = now()`
+2. **Deletes** the `SyncOverride(REOPENED)` record for this item
+3. Returns the standard complete response (no change to existing contract)
+
+This ensures the override lifecycle is clean: open → complete → reopen → re-complete removes the override.

--- a/specs/002-uncheck-completed/data-model.md
+++ b/specs/002-uncheck-completed/data-model.md
@@ -1,0 +1,105 @@
+# Data Model: Uncheck Completed Tasks
+
+## Existing Models (relevant fields)
+
+### NativeTask *(no schema changes needed)*
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | `String` UUID | Primary key |
+| `userId` | `String` | FK → User |
+| `completed` | `Boolean` | `false` = open, `true` = complete |
+| `completedAt` | `DateTime?` | Null when open |
+
+**Uncomplete behavior**: Set `completed = false`, `completedAt = null`.
+
+---
+
+### SyncCacheItem *(no schema changes needed)*
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | `String` UUID | Primary key |
+| `userId` | `String` | FK → User |
+| `completedInOrdrctrl` | `Boolean` | `true` when user marked complete in ordrctrl |
+| `completedAt` | `DateTime?` | Null when open |
+
+**Uncomplete behavior**: Set `completedInOrdrctrl = false`, `completedAt = null`.
+
+---
+
+## New Model: SyncOverride
+
+Tracks when a user has explicitly overridden the source system's completion state for a
+synced item. The sync engine checks for an active `REOPENED` override before applying a
+"completed" state from the source.
+
+```prisma
+model SyncOverride {
+  id              String         @id @default(uuid())
+  userId          String
+  syncCacheItemId String
+  overrideType    OverrideType
+  createdAt       DateTime       @default(now())
+
+  user            User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  syncCacheItem   SyncCacheItem  @relation(fields: [syncCacheItemId], references: [id], onDelete: Cascade)
+
+  @@unique([syncCacheItemId, overrideType])
+  @@index([userId])
+  @@index([syncCacheItemId])
+}
+
+enum OverrideType {
+  REOPENED
+}
+```
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | UUID | Primary key |
+| `userId` | String | Owner — used for authorization |
+| `syncCacheItemId` | String | FK → SyncCacheItem (cascade delete) |
+| `overrideType` | OverrideType | `REOPENED` for uncheck; extensible for future two-way sync |
+| `createdAt` | DateTime | When the override was created |
+
+### Constraints
+
+- `@@unique([syncCacheItemId, overrideType])` — only one active override per item per type
+- Cascade deletes: removing a SyncCacheItem removes its overrides automatically
+- Re-checking a reopened item (re-completing it) MUST delete the associated `SyncOverride` record
+
+---
+
+## State Transitions
+
+### Native Task
+
+```
+open ──[check]──► complete
+complete ──[uncheck]──► open
+```
+
+### Sync Cache Item
+
+```
+open ──[check]──► completedInOrdrctrl=true
+completedInOrdrctrl=true ──[uncheck]──► completedInOrdrctrl=false + SyncOverride(REOPENED) created
+SyncOverride(REOPENED) exists ──[sync cycle, source=complete]──► ignore source state (override wins)
+SyncOverride(REOPENED) exists ──[re-check by user]──► completedInOrdrctrl=true + SyncOverride deleted
+```
+
+---
+
+## Sync Conflict Resolution Logic
+
+When a sync cycle processes an item that the user has reopened:
+
+```
+if SyncOverride(REOPENED) exists for item:
+    skip updating completedInOrdrctrl (user override wins)
+else:
+    apply source completion state as normal
+```

--- a/specs/002-uncheck-completed/plan.md
+++ b/specs/002-uncheck-completed/plan.md
@@ -1,0 +1,88 @@
+# Implementation Plan: Uncheck Completed Tasks
+
+**Branch**: `002-uncheck-completed` | **Date**: 2026-03-07 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/002-uncheck-completed/spec.md`
+
+## Summary
+
+Allow users to reopen completed tasks by unchecking them in the Completed section of the feed.
+For native tasks, this sets `completed=false` in the database. For integration-sourced tasks,
+this clears the `completedInOrdrctrl` flag and stores a Sync Override record to prevent future
+sync cycles from re-completing the item. The user's local override always wins over source state.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.4 (backend: Node.js/Fastify; frontend: React/Next.js 14)
+**Primary Dependencies**: Fastify (backend API), React + Tailwind CSS (frontend), Prisma ORM
+**Storage**: PostgreSQL 16 (primary data), Redis 7 (session cache, BullMQ job queue)
+**Testing**: Vitest + Supertest (backend), Playwright (frontend E2E)
+**Target Platform**: Web (desktop + mobile browser)
+**Project Type**: Web application (monorepo: `backend/` + `frontend/`)
+**Performance Goals**: Uncomplete action reflects in UI immediately (optimistic update, <100ms perceived)
+**Constraints**: Sync cycles MUST NOT overwrite a user's explicit reopen; one-way sync constraint unchanged
+**Scale/Scope**: Per-user action; touches feed state, task service, and sync cache service
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Integration Modularity | ✅ PASS | Sync Override logic lives in feed service; no integration adapter code changes required |
+| II. Minimalism-First | ✅ PASS | Feature is justified by concrete user scenario (US1/US2 in spec); no new UI surfaces added |
+| III. Security & Privacy by Default | ✅ PASS | No new token handling; no new data persisted beyond task state flags |
+| IV. Test Coverage Required | ✅ PASS | Unit tests for uncomplete service functions + route tests required (enforced in tasks) |
+| V. Simplicity & Deferred Decisions | ✅ PASS | No new dependencies; Sync Override is a minimal extension to existing SyncCacheItem model |
+
+**Complexity Tracking**: No violations. Schema already supports uncompleting (nullable fields). A new
+`SyncOverride` record uses existing Prisma model pattern; no new infrastructure needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-uncheck-completed/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+backend/
+├── prisma/
+│   ├── schema.prisma                         # Add SyncOverride model
+│   └── migrations/                           # New migration for SyncOverride table
+├── src/
+│   ├── feed/
+│   │   └── feed.service.ts                   # Add uncompleteNativeTask(), uncompleteSyncItem()
+│   ├── tasks/
+│   │   └── task.service.ts                   # Add uncompleteTask()
+│   └── api/
+│       ├── feed.routes.ts                    # Add PATCH /api/feed/items/:itemId/uncomplete
+│       └── tasks.routes.ts                   # Add PATCH /api/tasks/:id/uncomplete
+└── tests/
+    ├── unit/feed.service.test.ts             # Unit tests for uncomplete functions
+    └── contract/feed.routes.test.ts          # Route/contract tests
+
+frontend/
+├── src/
+│   ├── services/
+│   │   └── feed.service.ts                   # Add uncompleteItem() API call
+│   ├── hooks/
+│   │   └── useFeed.ts                        # Add uncompleteItem() with optimistic update
+│   └── components/feed/
+│       ├── CompletedSection.tsx              # Pass onUncomplete handler to FeedItemRow
+│       └── FeedItem.tsx                      # Enable checkbox click for completed items
+└── tests/
+    └── e2e/feed.spec.ts                      # E2E test: uncheck completed task
+```
+
+**Structure Decision**: Web application (Option 2). Changes span both `backend/` and `frontend/`
+in the existing monorepo structure. No new directories; modifications to existing service,
+route, hook, and component files only, plus one new Prisma model and migration.

--- a/specs/002-uncheck-completed/quickstart.md
+++ b/specs/002-uncheck-completed/quickstart.md
@@ -1,0 +1,48 @@
+# Quickstart: Uncheck Completed Tasks
+
+## What this feature changes
+
+Users can now click a completed task's checkbox in the Completed section to move it back
+to the active feed. The change persists across sessions and survives sync cycles.
+
+## Key files touched
+
+| Layer | File | Change |
+|-------|------|--------|
+| DB Schema | `backend/prisma/schema.prisma` | Add `SyncOverride` model + `OverrideType` enum |
+| DB Migration | `backend/prisma/migrations/` | New migration file |
+| Service | `backend/src/feed/feed.service.ts` | Add `uncompleteNativeTask()`, `uncompleteSyncItem()` |
+| Service | `backend/src/tasks/task.service.ts` | Add `uncompleteTask()` |
+| Routes | `backend/src/api/feed.routes.ts` | Add `PATCH /api/feed/items/:itemId/uncomplete` |
+| Routes | `backend/src/api/tasks.routes.ts` | Add `PATCH /api/tasks/:id/uncomplete` |
+| Routes | `backend/src/api/feed.routes.ts` | Modify complete handler to delete SyncOverride on re-complete |
+| API client | `frontend/src/services/feed.service.ts` | Add `uncompleteItem()` |
+| Hook | `frontend/src/hooks/useFeed.ts` | Add `uncompleteItem()` with optimistic update |
+| Component | `frontend/src/components/feed/CompletedSection.tsx` | Pass `onUncomplete` to FeedItemRow |
+| Component | `frontend/src/components/feed/FeedItem.tsx` | Enable checkbox click for completed items |
+
+## Running locally
+
+```bash
+# From repo root — start all services
+docker compose up -d
+
+# Apply new migration after schema change
+cd backend && pnpm prisma migrate dev --name add-sync-override
+
+# Run backend tests
+cd backend && pnpm test
+
+# Run frontend E2E tests
+cd frontend && pnpm test:e2e
+```
+
+## Key behavioral notes
+
+- **Native tasks**: Uncomplete sets `completed=false, completedAt=null`. No override needed.
+- **Sync items**: Uncomplete sets `completedInOrdrctrl=false, completedAt=null` AND creates
+  a `SyncOverride(REOPENED)` record. The sync job skips re-completing items with an active override.
+- **Re-checking a reopened sync item**: Deletes the `SyncOverride` record, restoring normal sync behavior.
+- **Inline notice**: Frontend shows a one-time notice on sync-sourced reopened items indicating
+  the change is local to ordrctrl. Flag lives in client state only (not persisted).
+- **Optimistic update**: UI moves the item immediately; rolls back on API failure.

--- a/specs/002-uncheck-completed/research.md
+++ b/specs/002-uncheck-completed/research.md
@@ -1,0 +1,94 @@
+# Research: Uncheck Completed Tasks
+
+## 1. Sync Conflict Resolution Pattern
+
+**Decision**: Local override always wins — user action takes precedence over source system state.
+
+**Rationale**: ordrctrl is a personal workspace of record. When a user explicitly reopens a
+task, that intent must be preserved across sync cycles. This matches the behavior of apps like
+Fantastical and Todoist, where the local app state is authoritative and sync is additive, not
+destructive.
+
+**Implementation**: A `SyncOverride` record (new Prisma model) is written when the user
+uncompletes a sync-sourced item. The background sync job checks for an existing override before
+applying a "completed" state from the source — if an override exists, the source state is
+ignored.
+
+**Alternatives considered**:
+- Source wins: Rejected — would silently undo user actions, creating a confusing UX.
+- User prompted at sync time: Rejected — too much friction for a common background operation.
+
+---
+
+## 2. Optimistic UI Update Pattern
+
+**Decision**: Move item from `completed` array back to `items` array immediately on uncheck,
+roll back on API failure.
+
+**Rationale**: The existing `completeItem()` in `useFeed.ts` already uses this pattern. Keeping
+the same approach ensures consistency in perceived performance and error handling behavior.
+
+**Implementation**: In `useFeed.ts`, `uncompleteItem()` will:
+1. Remove item from `completed` state immediately
+2. Re-insert at top of `items` state
+3. Call backend API
+4. On failure: reverse the move and show an error toast
+
+**Alternatives considered**:
+- Wait for API before updating UI: Rejected — latency would make checkbox feel broken.
+
+---
+
+## 3. Inline Notice for Integration-Sourced Items
+
+**Decision**: Show a brief dismissible inline notice below the reopened item the first time
+it appears back in the active feed, informing the user the change is local to ordrctrl only.
+
+**Rationale**: The spec (FR-003) requires this notice. One-time-per-item is sufficient —
+showing it on every view would be noisy. A "don't show again" option is out of scope.
+
+**Implementation**: Pass an `isJustReopened` flag from the `uncompleteItem()` state update.
+`FeedItem.tsx` renders a small inline note when `isJustReopened === true`. The flag lives
+only in client-side state (not persisted) and clears on page reload.
+
+**Alternatives considered**:
+- Toast notification: Rejected — toast is ephemeral and easy to miss; inline is more
+  discoverable and tied to the specific item.
+- Always show notice: Rejected — per spec, this is informational, not a permanent label.
+
+---
+
+## 4. API Design: Toggle vs. Separate Endpoints
+
+**Decision**: Separate endpoint — `PATCH /api/feed/items/:itemId/uncomplete` — rather than
+modifying the existing `complete` endpoint to toggle.
+
+**Rationale**: Separate endpoints are more explicit, easier to test, and prevent accidental
+double-fire toggling. The existing `complete` endpoint remains unchanged (no regression risk).
+
+**Alternatives considered**:
+- Single toggle endpoint (`PATCH /api/feed/items/:itemId/toggle`): Rejected — harder to
+  test intent; toggling can produce unexpected results if requests are duplicated.
+- Modify `updateTask()` to accept `completed: false`: Rejected — `updateTask` currently
+  intentionally excludes the `completed` field for safety; changing that broadens scope.
+
+---
+
+## 5. SyncOverride Schema Design
+
+**Decision**: Add a new `SyncOverride` Prisma model linked to `SyncCacheItem`.
+
+**Rationale**: Keeping override records separate from `SyncCacheItem` preserves the cache
+table's role as a pure sync mirror and allows the override concept to be extended toward
+two-way sync (issue #10) without schema migration later.
+
+**Fields**:
+- `id` — UUID primary key
+- `userId` — owner (for authorization checks)
+- `syncCacheItemId` — FK to `SyncCacheItem`
+- `overrideType` — enum: `REOPENED` (extensible to `COMPLETED`, `EDITED` for two-way sync)
+- `createdAt` — timestamp
+
+**Alternatives considered**:
+- Add `userOverrideCompleted: Boolean` directly to `SyncCacheItem`: Rejected — pollutes the
+  cache model and doesn't extend cleanly to future override types.

--- a/specs/002-uncheck-completed/spec.md
+++ b/specs/002-uncheck-completed/spec.md
@@ -1,0 +1,142 @@
+# Feature Specification: Uncheck Completed Tasks
+
+**Feature Branch**: `002-uncheck-completed`
+**Created**: 2026-03-06
+**Status**: Draft
+**Input**: Allow completed issues to be unchecked
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Reopen a Native Task (Priority: P1)
+
+A user marked a natively-created ordrctrl task as complete by mistake, or circumstances have
+changed and the task needs to be revisited. They open the Completed section, find the task,
+and uncheck it to move it back into the active feed.
+
+**Why this priority**: Native tasks are fully owned by ordrctrl, so this is the simplest and
+most unambiguous case. It must work first before handling integration-sourced items.
+
+**Independent Test**: Can be fully tested by creating a native task, marking it complete,
+then unchecking it from the Completed section — without any integrations connected. Delivers
+a working reopen flow.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has at least one item in the Completed section, **When** they uncheck the
+   item's checkbox, **Then** the item is removed from the Completed section and reappears in
+   the active feed.
+2. **Given** a reopened task in the active feed, **When** the user views the task, **Then** it
+   appears as an open, incomplete item with no completed styling.
+3. **Given** a user who unchecked a task, **When** they navigate away and return, **Then** the
+   task remains in the active feed (the state is persisted).
+4. **Given** the Completed section is open, **When** a user unchecks the last completed item,
+   **Then** the Completed section collapses or shows an empty state gracefully.
+
+---
+
+### User Story 2 - Reopen an Integration-Sourced Task (Priority: P2)
+
+A user marked a synced task (from Gmail, Apple Reminders, Microsoft Tasks, or Apple Calendar)
+as complete within ordrctrl. They later decide to reopen it in the feed. Because sync is
+one-way (ordrctrl reads from integrations but does not write back), unchecking restores the
+item's visible status in ordrctrl only.
+
+**Why this priority**: Integration tasks make up the majority of a user's feed, so supporting
+reopen for synced items delivers high value. The one-way sync constraint must be clearly
+communicated.
+
+**Independent Test**: Can be tested with any connected integration by marking a synced item
+complete, then unchecking it. The item should reappear in the active feed without any changes
+in the source system.
+
+**Acceptance Scenarios**:
+
+1. **Given** a completed integration-sourced task in the Completed section, **When** the user
+   unchecks it, **Then** the item moves back to the active feed and displays its source
+   integration badge.
+2. **Given** a reopened integration-sourced task, **When** the next background sync runs,
+   **Then** the task's open status in ordrctrl is preserved (the sync does not re-complete it
+   unless the source still marks it complete).
+3. **Given** a user unchecking a synced task, **When** the reopen action occurs, **Then** a
+   brief inline notice informs the user that this change is local to ordrctrl and will not
+   update the source application.
+4. **Given** a source integration still shows the task as complete, **When** sync runs after
+   the user has reopened it in ordrctrl, **Then** the user's local reopen is preserved —
+   ordrctrl acts as the personal workspace of record and a user action always takes
+   precedence over the source system's state.
+
+---
+
+### Edge Cases
+
+- What happens when a user unchecks a task and then immediately rechecks it? The task should
+  toggle back to complete and return to the Completed section without error.
+- What happens if the Completed section is collapsed when a user reopens a task via keyboard
+  or accessibility shortcut? The Completed section should open first before the item moves.
+- How does the system handle unchecking a task that was completed during the current session
+  vs. a previous session? Behavior should be identical in both cases.
+- What if connectivity is lost when the user attempts to uncheck a task? The action should
+  fail gracefully with a user-friendly error and the item should remain in the Completed
+  section until the action succeeds.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Users MUST be able to uncheck any item in the Completed section to move it back
+  to the active feed.
+- **FR-002**: The system MUST persist the reopened state of a task across page refreshes and
+  sessions.
+- **FR-003**: When unchecking an integration-sourced task, the system MUST display an inline
+  notice informing the user the change is local to ordrctrl only.
+- **FR-004**: Reopened integration-sourced tasks MUST retain their source integration badge
+  and metadata in the active feed.
+- **FR-005**: When a sync cycle runs after a user has manually reopened a synced task, the
+  system MUST preserve the user's local override — the source system's completion state MUST
+  NOT overwrite a user's explicit reopen action.
+- **FR-006**: If the Completed section is empty after unchecking the last item, the section
+  MUST collapse or display a clear empty state without layout errors.
+- **FR-007**: The uncheck interaction MUST be accessible via keyboard and screen readers
+  (same pattern as the check interaction).
+- **FR-008**: Unchecking a task MUST be reversible — the user can re-check it at any time to
+  move it back to the Completed section.
+
+### Key Entities
+
+- **Task**: Represents a single actionable item in the feed. Has a completion status
+  (open/complete), a source (native or integration name), and associated metadata. This
+  feature adds the concept of a user-overridden status distinct from the source system's
+  status.
+- **Sync Override**: A record indicating the user has manually changed the completion state
+  of an integration-sourced task, allowing the sync engine to respect the user's intent.
+
+### Assumptions
+
+- The Completed section already exists as a collapsible section at the bottom of the feed
+  (established in MVP).
+- Sync is currently one-way: ordrctrl reads from integrations but does not write back.
+  This feature does not change that constraint.
+- The uncheck affordance (checkbox) is the same UI element used to mark items complete,
+  simply toggled in reverse.
+- Task completion state is stored per-user in ordrctrl's data layer and is not derived
+  solely from the source system's state.
+- **ordrctrl is the personal workspace of record**: user actions always take precedence
+  over source system state. The `Sync Override` entity is designed to be extensible —
+  when two-way sync is introduced in a future feature, override records can become
+  pending write-back items to push user intent back to the source system.
+- Selective import of tasks per integration (choosing which tasks to pull in) is
+  out of scope for this feature and should be specified separately (see issue #11).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can reopen a completed task in under 5 seconds from opening the
+  Completed section.
+- **SC-002**: 100% of reopened native tasks appear in the active feed immediately with no
+  page reload required.
+- **SC-003**: 100% of reopened tasks persist their open state across sessions.
+- **SC-004**: The inline notice for integration-sourced tasks is displayed on every uncheck
+  action with zero false negatives.
+- **SC-005**: Zero layout errors or empty-state failures occur when the last completed item
+  is unchecked.

--- a/specs/002-uncheck-completed/tasks.md
+++ b/specs/002-uncheck-completed/tasks.md
@@ -1,0 +1,160 @@
+# Tasks: Uncheck Completed Tasks
+
+**Input**: Design documents from `/specs/002-uncheck-completed/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/api.md ✅, quickstart.md ✅
+
+**Organization**: Tasks grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1 = native tasks, US2 = sync-sourced tasks)
+- Paths follow web app convention: `backend/` and `frontend/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Schema migration and new model — required before any service or route work.
+
+- [ ] T001 Add `OverrideType` enum and `SyncOverride` model to `backend/prisma/schema.prisma`
+- [ ] T002 Generate and run Prisma migration: `prisma migrate dev --name add-sync-override` (creates `backend/prisma/migrations/`)
+- [ ] T003 Regenerate Prisma client after migration (`prisma generate`)
+
+**Checkpoint**: `SyncOverride` table exists in the database. Prisma client reflects the new model.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Backend service functions and API routes that both user stories depend on.
+
+- [ ] T004 Add `uncompleteNativeTask(taskId, userId)` to `backend/src/tasks/task.service.ts` — sets `completed=false, completedAt=null`, throws `ITEM_NOT_FOUND` / `FORBIDDEN` / `ITEM_NOT_COMPLETED` as needed
+- [ ] T005 [P] Add `uncompleteNativeTask(taskId, userId)` to `backend/src/feed/feed.service.ts` — thin wrapper calling task service, returns normalized feed item shape
+- [ ] T006 [P] Add `uncompleteSyncItem(itemId, userId)` to `backend/src/feed/feed.service.ts` — sets `completedInOrdrctrl=false, completedAt=null` AND creates `SyncOverride(REOPENED)` record; returns `isLocalOverride: true`
+- [ ] T007 Add `PATCH /api/feed/items/:itemId/uncomplete` route to `backend/src/api/feed.routes.ts` — authenticates user, resolves item type, delegates to correct service function, returns contract response from `contracts/api.md`
+- [ ] T008 Add `PATCH /api/tasks/:id/uncomplete` route to `backend/src/api/tasks.routes.ts` — authenticates user, calls `uncompleteTask`, returns contract response
+- [ ] T009 Modify `PATCH /api/feed/items/:itemId/complete` handler in `backend/src/api/feed.routes.ts` to delete any existing `SyncOverride(REOPENED)` for the item when re-completing a sync-sourced task
+
+**Checkpoint**: `PATCH /api/feed/items/:itemId/uncomplete` and `PATCH /api/tasks/:id/uncomplete` return correct responses. Re-completing a reopened sync item deletes the override. Backend tests pass (`pnpm test`).
+
+---
+
+## Phase 3: User Story 1 — Reopen a Native Task (Priority: P1) 🎯 MVP
+
+**Goal**: A user can uncheck a completed native ordrctrl task and have it return to the active feed, persisted across sessions.
+
+**Independent Test**: Create a native task → mark it complete → uncheck it from the Completed section → verify it appears in the active feed → refresh page → verify it remains in the active feed. No integrations needed.
+
+### Implementation
+
+- [ ] T010 [US1] Add `uncompleteItem(itemId: string): Promise<void>` to `frontend/src/services/feed.service.ts` — calls `PATCH /api/feed/items/:itemId/uncomplete`
+- [ ] T011 [US1] Add `uncompleteItem(itemId)` callback to `frontend/src/hooks/useFeed.ts` — optimistic update: immediately removes item from `completed` array and re-inserts at top of `items` array; rolls back both arrays and shows error toast on API failure
+- [ ] T012 [US1] Update `frontend/src/components/feed/CompletedSection.tsx` to accept and forward `onUncomplete` prop to each `FeedItemRow`
+- [ ] T013 [US1] Update `frontend/src/components/feed/FeedItem.tsx` to enable checkbox click for completed items: when `item.completed === true`, clicking checkbox calls `onUncomplete(item.id)` instead of being a no-op; update aria-label to "Reopen task"
+- [ ] T014 [US1] Wire `onUncomplete={uncompleteItem}` from `useFeed` hook into `<CompletedSection>` in `frontend/src/app/feed/page.tsx`
+
+**Checkpoint**: Native task can be checked, unchecked, and rechecked repeatedly. State persists on page reload. Error state rolls back the UI correctly.
+
+---
+
+## Phase 4: User Story 2 — Reopen an Integration-Sourced Task (Priority: P2)
+
+**Goal**: A user can uncheck a completed sync-sourced task. The item returns to the active feed with its integration badge, and a sync override prevents the next sync cycle from re-completing it.
+
+**Independent Test**: Connect any integration → let it sync → mark a synced item complete → uncheck it → verify it reappears with its source badge and the inline "local change" notice → trigger a manual sync → verify the item remains open in the feed.
+
+### Implementation
+
+- [ ] T015 [P] [US2] Update `frontend/src/hooks/useFeed.ts` `uncompleteItem()` to read `isLocalOverride` from the API response and attach it as `isJustReopened: true` flag on the item in the `items` state array
+- [ ] T016 [P] [US2] Update `frontend/src/components/feed/FeedItem.tsx` to render a dismissible inline notice below the item when `item.isJustReopened === true` and `item.source !== 'ordrctrl'`: text reads "This change is local to ordrctrl and won't update [source name]." Notice clears when dismissed or on next render cycle
+- [ ] T017 [US2] Update background sync job (locate in `backend/src/`) to check for an existing `SyncOverride(REOPENED)` before setting `completedInOrdrctrl=true` on a `SyncCacheItem` — if override exists, skip the completion update for that item
+
+**Checkpoint**: Synced task can be unchecked. Inline notice appears and can be dismissed. Manual sync does not re-complete the item. Re-checking the item removes the sync override and allows future syncs to set it complete again.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Edge cases, accessibility, and error handling across both user stories.
+
+- [ ] T018 [P] Add Vitest unit tests for `uncompleteNativeTask()` and `uncompleteSyncItem()` in `backend/tests/unit/feed.service.test.ts` — cover success, `ITEM_NOT_COMPLETED`, `FORBIDDEN`, `ITEM_NOT_FOUND` cases
+- [ ] T019 [P] Add Vitest contract tests for `PATCH /api/feed/items/:itemId/uncomplete` in `backend/tests/contract/feed.routes.test.ts` — cover 200, 400, 403, 404 responses per `contracts/api.md`
+- [ ] T020 [P] Add Playwright E2E test for native task uncheck flow in `frontend/tests/e2e/feed.spec.ts`
+- [ ] T021 Verify `CompletedSection` collapses or shows empty state when last item is unchecked — fix in `frontend/src/components/feed/CompletedSection.tsx` if needed
+- [ ] T022 Verify keyboard navigation works for unchecking (checkbox focusable and operable via Space/Enter) in `frontend/src/components/feed/FeedItem.tsx`
+- [ ] T023 Verify error toast displays correctly when `uncompleteItem()` API call fails and optimistic update is rolled back — test in `frontend/src/hooks/useFeed.ts`
+- [ ] T024 Run `quickstart.md` validation: confirm full flow works end-to-end with `docker compose up` + fresh migration
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1 (T001–T003 complete, schema migrated)
+- **Phase 3 (US1)**: Depends on Phase 2 (T004–T009 complete)
+- **Phase 4 (US2)**: Depends on Phase 2 (T004–T009 complete) — can run in parallel with Phase 3
+- **Phase 5 (Polish)**: Depends on Phase 3 and Phase 4 complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Foundational only — no dependency on US2
+- **US2 (P2)**: Depends on Foundational only — no dependency on US1 (backend already handles both via service layer)
+
+### Within Each Phase
+
+- T005 and T006 can run in parallel (different service functions, same file — coordinate)
+- T010–T014 are sequential within US1 (service → hook → component → wire-up)
+- T015 and T016 can run in parallel within US2 (different concerns)
+- T018–T020 can all run in parallel in Polish phase
+
+---
+
+## Parallel Example: Phase 2 (Foundational)
+
+```bash
+# After T004 completes:
+Task T005: "Add uncompleteNativeTask() to backend/src/feed/feed.service.ts"
+Task T006: "Add uncompleteSyncItem() to backend/src/feed/feed.service.ts"
+# Then T007–T009 sequentially
+```
+
+## Parallel Example: Phase 3 + Phase 4 (if two developers)
+
+```bash
+# Developer A: Phase 3 (US1 - native tasks)
+Task T010 → T011 → T012 → T013 → T014
+
+# Developer B: Phase 4 (US2 - sync override)
+Task T015, T016 (parallel) → T017
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Schema migration (T001–T003)
+2. Complete Phase 2: Backend services + routes (T004–T009)
+3. Complete Phase 3: Frontend for native tasks (T010–T014)
+4. **STOP and VALIDATE**: Native task uncheck works end-to-end
+5. Ship if ready — US2 adds sync protection but US1 delivers the core user value
+
+### Incremental Delivery
+
+1. **Phase 1 + 2** → Backend API is complete and testable with curl
+2. **Phase 3** → Native task uncheck works in UI (MVP shippable)
+3. **Phase 4** → Sync-sourced task uncheck works with override protection
+4. **Phase 5** → Tests, edge cases, accessibility hardened
+
+---
+
+## Notes
+
+- [P] tasks = different files or independent concerns, no blocking dependencies
+- `SyncOverride` is intentionally minimal — `overrideType` enum is extensible toward two-way sync (issue #10) without schema changes
+- Re-completing a reopened item MUST delete the `SyncOverride` record (T009) — verify this in Polish phase
+- `isJustReopened` flag is client-state only — not persisted, clears on page reload


### PR DESCRIPTION
- Add SyncOverride model + OverrideType enum to schema (migration included)
- Add uncompleteNativeTask() and uncompleteSyncItem() to feed.service.ts
- Add uncompleteTask() to task.service.ts
- Add PATCH /api/feed/items/:itemId/uncomplete route
- Add PATCH /api/tasks/:id/uncomplete route
- Delete SyncOverride(REOPENED) when item is re-completed (clean lifecycle)
- Guard cache.service.ts upsert: never overwrites local completedInOrdrctrl state
- Frontend: uncompleteItem() service call + optimistic update in useFeed
- CompletedSection forwards onUncomplete prop to each FeedItemRow
- FeedItem: checkbox enabled for completed items (aria-label: Reopen task)
- FeedItem: dismissible inline notice for sync-sourced reopened items
- Wire onUncomplete={uncompleteItem} in feed page
- 9 new unit tests (uncompleteNativeTask, uncompleteSyncItem) + 5 new contract tests
- All 46 backend tests pass, TypeScript clean on both packages